### PR TITLE
fix(debug): increment inspect port

### DIFF
--- a/lib/actor-system.js
+++ b/lib/actor-system.js
@@ -670,18 +670,21 @@ class ActorSystem {
       let balancerActor = await this._createBalancerActor(definition, parent, config);
 
       let childPromises = _.times(config.clusterSize, () =>
-        balancerActor.createChild(definition, _.extend({}, config, { clusterSize: 1 })));
+        balancerActor.createChild(
+          definition,
+          _.extend({}, config, { clusterSize: 1, actorNumber: this.debugPortCounter++ })
+        )
+      );
 
       return P.all(childPromises).return(balancerActor);
     }
 
-    let actor =
-      new ForkedActorParent({
-        system: this,
-        parent: parent,
-        definition: definition,
-        additionalOptions: config
-      });
+    let actor = new ForkedActorParent({
+      system: this,
+      parent: parent,
+      definition: definition,
+      additionalOptions: Object.assign({ actorNumber: this.debugPortCounter++ }, config)
+    });
 
     this.bus.addForkedRecipient(actor);
 

--- a/lib/forked-actor-parent.js
+++ b/lib/forked-actor-parent.js
@@ -195,7 +195,7 @@ class ForkedActorParent extends ForkedActor {
   _createForkExecArgv(parentExecArgv) {
     // Handle debugging: increment debugger port for child process.
     const execArgv = _.map(parentExecArgv, arg => {
-      let match = arg.match(/^(--inspect(?:-brk)?|--debug(?:-brk)?)(?:=([\d\.]+)(?::(\d+))?)?/);
+      let match = arg.match(/^(--inspect(?:-brk)?|--debug(?:-brk)?)(?:=((?:\d+\.)+\d+)?(?::?(\d+))?)/);
 
       if (match) {
         const [, cmd, host, port] = match;

--- a/lib/forked-actor-parent.js
+++ b/lib/forked-actor-parent.js
@@ -113,39 +113,16 @@ class ForkedActorParent extends ForkedActor {
 
       this.name && psArgs.push(this.name);
 
-      // Handle debugging: increment debugger port for child process.
-      let execArgv = _.map(process.execArgv, arg => {
-        let match = arg.match(
-          /^(--inspect(?:-brk)?|--debug(?:-brk)?)(?:=([\d\.]+)(?::(\d+))?)?/
-        );
+      const execArgv = this._createForkExecArgv(process.execArgv);
 
-        if (match) {
-          const [, cmd, host, port] = match;
-          let debugPort = parseInt(port);
-
-          let incPortCmd = cmd;
-          incPortCmd += host ? '=' + host : '';
-          incPortCmd += debugPort
-            ? ':' + (debugPort + this.config.actorNumber)
-            : '';
-
-          return incPortCmd;
-        }
-
-        return arg;
+      this.workerProcess = childProcess.fork(path.join(__dirname, '/forked-actor-worker.js'), psArgs, {
+        execArgv: execArgv
       });
-
-      this.workerProcess =
-        childProcess.fork(path.join(__dirname, '/forked-actor-worker.js'), psArgs, { execArgv: execArgv });
 
       this.log.debug('Forked new worker process, PID:', this.workerProcess.pid);
 
       return this.getSystem()
-        .generateActorCreationMessage(
-          this.definition,
-          this,
-          _.defaults({ mode: 'forked' }, this.additionalOptions)
-        )
+        .generateActorCreationMessage(this.definition, this, _.defaults({ mode: 'forked' }, this.additionalOptions))
         .then(createMsg => {
           return new P((resolve, reject) => {
             const errCb = (err) => {
@@ -213,6 +190,28 @@ class ForkedActorParent extends ForkedActor {
           });
         });
     });
+  }
+
+  _createForkExecArgv(parentExecArgv) {
+    // Handle debugging: increment debugger port for child process.
+    const execArgv = _.map(parentExecArgv, arg => {
+      let match = arg.match(/^(--inspect(?:-brk)?|--debug(?:-brk)?)(?:=([\d\.]+)(?::(\d+))?)?/);
+
+      if (match) {
+        const [, cmd, host, port] = match;
+        let debugPort = parseInt(port);
+
+        let incPortCmd = cmd;
+        incPortCmd += host ? '=' + host : '';
+        incPortCmd += debugPort ? ':' + (debugPort + this.config.actorNumber) : '';
+
+        return incPortCmd;
+      }
+
+      return arg;
+    });
+
+    return execArgv;
   }
 }
 

--- a/lib/forked-actor-parent.js
+++ b/lib/forked-actor-parent.js
@@ -115,12 +115,21 @@ class ForkedActorParent extends ForkedActor {
 
       // Handle debugging: increment debugger port for child process.
       let execArgv = _.map(process.execArgv, arg => {
-        let match = arg.match(/^--debug-brk=(\d+)/);
+        let match = arg.match(
+          /^(--inspect(?:-brk)?|--debug(?:-brk)?)(?:=([\d\.]+)(?::(\d+))?)?/
+        );
 
         if (match) {
-          let debugPort = parseInt(match[1]);
+          const [, cmd, host, port] = match;
+          let debugPort = parseInt(port);
 
-          return '--debug-brk=' + (debugPort + this.debugPortCounter++);
+          let incPortCmd = cmd;
+          incPortCmd += host ? '=' + host : '';
+          incPortCmd += debugPort
+            ? ':' + (debugPort + this.config.actorNumber)
+            : '';
+
+          return incPortCmd;
         }
 
         return arg;


### PR DESCRIPTION
Forking actors during debugging causes the following error for me:

> Starting inspector on 0.0.0.0:9229 failed: address already in use

This is because the port number is not incremented. 

In this fix I'm passing the current number of an actor to itself then I'm checking the debug and inspect flags in the args to determine do I need to increment the port and fork a process in debug mode.