### PR TITLE
fix(in-memory-actor) emits warning about promise handler

### DIFF
--- a/lib/in-memory-actor.js
+++ b/lib/in-memory-actor.js
@@ -81,6 +81,8 @@ class InMemoryActor extends Actor {
             .finally(() => {
               this._afterHandled();
             });
+
+            return null;
         }
         else {
           this._afterHandled();


### PR DESCRIPTION
if you run the getting started example with the `node --trace-warnings` flag it yields the following error [Warning: a promise was created in a handler but was not returned from it](http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it)

this fixes it. I return `null` instead of the inner ` P.resolve()` because the function originally had no return, so this doesn't introduce any new behaviour.

If it should return a value then I will gladly make the change.